### PR TITLE
이벤트 페이지의 slick 슬라이더의 사용성을 개선합니다

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -74,7 +74,8 @@ $(function(){
     slidesToShow: 1,
     arrows: false,
     centerMode: true,
-    centerPadding: '40px',
+    focusOnSelect: true,
+    centerPadding: '5%',
     responsive: [{
       breakpoint: 768,
       settings: {

--- a/app/assets/stylesheets/_events.scss
+++ b/app/assets/stylesheets/_events.scss
@@ -12,5 +12,13 @@
     background-color: $gray-lightest;
     width: 80%;
     border-right: 1px solid #fff;
+    opacity: 0.8;
+    transition: opacity 0.2s;
+  }
+  .event_block:hover {
+    opacity: 1;
+  }
+  .slick-active {
+    opacity: 1;
   }
 }


### PR DESCRIPTION
- padding slider를 흐릿하게 보여줍니다
- padding slider에 커서를 올리면 진하게 보여줍니다
- slider를 클릭하면 해당 슬라이더로 이동합니다